### PR TITLE
Add beacon room change trigger and closest node condition

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,7 +1,7 @@
 {
   "_comment": "This file is generated. Please edit .homeycompose/app.json instead.",
   "id": "nl.mennovanhout.espresense",
-  "version": "1.0.8",
+  "version": "1.1.1",
   "compatibility": ">=5.0.0",
   "sdk": 3,
   "platforms": [
@@ -11,7 +11,8 @@
     "en": "ESPresense"
   },
   "description": {
-    "en": "Make personalised flows with ESPresense"
+    "en": "Make personalised flows with ESPresense",
+    "nl": "Maak gepersonaliseerde flows met ESPresense"
   },
   "category": [
     "tools"
@@ -30,6 +31,14 @@
   "homepage": "https://hdashboards.app",
   "support": "https://hdashboards.app",
   "source": "https://github.com/mennovanhout/homey-espresense",
+  "contributors": {
+    "developers": [
+      {
+        "name": "Michel Hoek",
+        "email": "mahoek@gmail.com"
+      }
+    ]
+  },
   "contributing": {
     "donate": {
       "bunq": {
@@ -43,10 +52,12 @@
       {
         "id": "when-device-is-closer-than-x-meters",
         "title": {
-          "en": "When device is closer than x meters"
+          "en": "When beacon is closer than x meters",
+          "nl": "Als beacon dichter bij is dan x meter"
         },
         "titleFormatted": {
-          "en": "When device [[deviceId]] is closer than [[distance]] meters"
+          "en": "When beacon [[deviceId]] is closer than [[distance]] meters",
+          "nl": "Als beacon [[deviceId]] dichter bij is dan [[distance]] meter"
         },
         "args": [
           {
@@ -58,14 +69,15 @@
             "type": "autocomplete",
             "name": "deviceId",
             "placeholder": {
-              "en": "device"
+              "en": "Beacon"
             }
           },
           {
             "type": "number",
             "name": "distance",
             "placeholder": {
-              "en": "distance"
+              "en": "Distance",
+              "nl": "Afstand"
             },
             "min": 0,
             "max": 16,
@@ -77,7 +89,8 @@
             "type": "number",
             "name": "device-distance",
             "title": {
-              "en": "Device distance"
+              "en": "Beacon distance",
+              "nl": "Beacon afstand"
             },
             "example": {
               "en": "1.2"
@@ -88,10 +101,12 @@
       {
         "id": "when-device-is-further-than-x-meters",
         "title": {
-          "en": "When device is further than x meters"
+          "en": "When beacon is further than x meters",
+          "nl": "Als beacon verder is dan x meter"
         },
         "titleFormatted": {
-          "en": "When device [[deviceId]] is further than [[distance]] meters"
+          "en": "When device [[deviceId]] is further than [[distance]] meters",
+          "nl": "Als beacon [[deviceId]] verder is dan [[distance]] meter"
         },
         "args": [
           {
@@ -103,14 +118,15 @@
             "type": "autocomplete",
             "name": "deviceId",
             "placeholder": {
-              "en": "device"
+              "en": "Beacon"
             }
           },
           {
             "type": "number",
             "name": "distance",
             "placeholder": {
-              "en": "distance"
+              "en": "Distance",
+              "nl": "Afstand"
             },
             "min": 0,
             "max": 16,
@@ -122,7 +138,8 @@
             "type": "number",
             "name": "device-distance",
             "title": {
-              "en": "Device distance"
+              "en": "Beacon distance",
+              "nl": "Beacon afstand"
             },
             "example": {
               "en": "1.2"
@@ -133,10 +150,12 @@
       {
         "id": "when-device-is-no-longer-detected",
         "title": {
-          "en": "When device is no longer detected"
+          "en": "When beacon is no longer detected",
+          "nl": "Als beacon niet meer is gedetecteerd"
         },
         "titleFormatted": {
-          "en": "When device [[deviceId]] is no longer detected"
+          "en": "When beacon [[deviceId]] is no longer detected",
+          "nl": "Als beacon [[deviceId]] niet meer is gedetecteerd"
         },
         "args": [
           {
@@ -148,7 +167,7 @@
             "type": "autocomplete",
             "name": "deviceId",
             "placeholder": {
-              "en": "device"
+              "en": "Beacon"
             }
           }
         ]
@@ -156,10 +175,12 @@
       {
         "id": "beacon-when-device-is-no-longer-detected",
         "title": {
-          "en": "When device is not detected within x minutes"
+          "en": "When beacon is not detected within x minutes",
+          "nl": "Als beacon niet meer binnen x minuten is gedetecteerd"
         },
         "titleFormatted": {
-          "en": "When device is not detected within [[duration]] minutes"
+          "en": "When beacon is not detected within [[duration]] minutes",
+          "nl": "Als beacon niet meer binnen [[duration]] minuten is gedetecteerd"
         },
         "args": [
           {
@@ -171,7 +192,8 @@
             "type": "number",
             "name": "duration",
             "placeholder": {
-              "en": "duration"
+              "en": "Duration",
+              "nl": "Duur"
             },
             "min": 1,
             "max": 60,
@@ -182,10 +204,12 @@
       {
         "id": "beacon-when-device-is-detected-after-x-minutes",
         "title": {
-          "en": "When device is detected again after x minutes"
+          "en": "When beacon is detected again after x minutes",
+          "nl": "Als beacon weer is gedetecteerd na x minuten"
         },
         "titleFormatted": {
-          "en": "When device is detected again after [[duration]] minutes"
+          "en": "When beacon is detected again after [[duration]] minutes",
+          "nl": "Als beacon weer is gedetecteerd na [[duration]] minuten"
         },
         "args": [
           {
@@ -197,11 +221,115 @@
             "type": "number",
             "name": "duration",
             "placeholder": {
-              "en": "duration"
+              "en": "Duration",
+              "nl": "Duur"
             },
             "min": 1,
             "max": 60,
             "step": 1
+          }
+        ]
+      },
+      {
+        "id": "beacon-when-room-changes",
+        "title": {
+          "en": "When beacon changes room",
+          "nl": "Als beacon van ruimte wisselt"
+        },
+        "titleFormatted": {
+          "en": "When beacon changes room",
+          "nl": "Als beacon van ruimte wisselt"
+        },
+        "tokens": [
+          {
+            "type": "string",
+            "name": "room-name",
+            "title": {
+              "en": "New room",
+              "nl": "Nieuwe ruimte"
+            },
+            "example": {
+              "en": "Bedroom front"
+            }
+          },
+          {
+            "type": "string",
+            "name": "room-id",
+            "title": {
+              "en": "New room ID",
+              "nl": "Nieuwe ruimte ID"
+            },
+            "example": {
+              "en": "bedroom-front"
+            }
+          },
+          {
+            "type": "string",
+            "name": "previous-room-name",
+            "title": {
+              "en": "Previous room",
+              "nl": "Vorige ruimte"
+            },
+            "example": {
+              "en": "Storage 1"
+            }
+          },
+          {
+            "type": "string",
+            "name": "previous-room-id",
+            "title": {
+              "en": "Previous room ID",
+              "nl": "Vorige ruimte ID"
+            },
+            "example": {
+              "en": "storage-1"
+            }
+          },
+          {
+            "type": "number",
+            "name": "distance",
+            "title": {
+              "en": "Distance",
+              "nl": "Afstand"
+            },
+            "example": {
+              "en": "1.2"
+            }
+          }
+        ],
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=espresense_beacon"
+          }
+        ]
+      }
+    ],
+    "conditions": [
+      {
+        "id": "beacon-is-in-room",
+        "title": {
+          "en": "Closest node is room",
+          "nl": "Dichtstbijzijnde node is ruimte"
+        },
+        "titleFormatted": {
+          "en": "Closest node is [[roomId]]",
+          "nl": "Dichtstbijzijnde node is [[roomId]]"
+        },
+        "args": [
+          {
+            "type": "device",
+            "name": "device",
+            "filter": "driver_id=espresense_beacon"
+          },
+          {
+            "type": "autocomplete",
+            "name": "roomId",
+            "placeholder": {
+              "en": "Room",
+              "nl": "Ruimte"
+            }
           }
         ]
       }
@@ -217,6 +345,16 @@
         "espresense_max_distance_capability",
         "espresense_status_capability"
       ],
+      "capabilitiesOptions": {
+        "espresense_status_capability": {
+          "titleTrue": {
+            "en": "Online"
+          },
+          "titleFalse": {
+            "en": "Offline"
+          }
+        }
+      },
       "platforms": [
         "local"
       ],
@@ -257,9 +395,20 @@
       "class": "other",
       "capabilities": [
         "espresense_beacon_room",
+        "espresense_beacon_roomname",
         "espresense_distance_capability",
         "espresense_status_capability"
       ],
+      "capabilitiesOptions": {
+        "espresense_status_capability": {
+          "titleTrue": {
+            "en": "Online"
+          },
+          "titleFalse": {
+            "en": "Offline"
+          }
+        }
+      },
       "platforms": [
         "local"
       ],
@@ -291,18 +440,32 @@
     "espresense_beacon_room": {
       "type": "string",
       "title": {
-        "en": "Room"
+        "en": "Room ID",
+        "nl": "Ruimte ID"
+      },
+      "uiComponent": null,
+      "getable": true,
+      "setable": false,
+      "icon": "assets/icons/room.svg",
+      "insights": false
+    },
+    "espresense_beacon_roomname": {
+      "type": "string",
+      "title": {
+        "en": "Room",
+        "nl": "Ruimte"
       },
       "uiComponent": "sensor",
       "getable": true,
       "setable": false,
       "icon": "assets/icons/room.svg",
-      "insights": true
+      "insights": false
     },
     "espresense_distance_capability": {
       "type": "number",
       "title": {
-        "en": "Distance"
+        "en": "Distance",
+        "nl": "Afstand"
       },
       "uiComponent": "sensor",
       "getable": true,
@@ -315,7 +478,8 @@
     "espresense_max_distance_capability": {
       "type": "number",
       "title": {
-        "en": "Max distance"
+        "en": "Max distance",
+        "nl": "Max afstand"
       },
       "uiComponent": "sensor",
       "getable": true,
@@ -326,28 +490,21 @@
       "icon": "assets/icons/ruler.svg"
     },
     "espresense_status_capability": {
-      "type": "enum",
+      "type": "boolean",
       "title": {
         "en": "Status"
       },
       "uiComponent": "sensor",
       "getable": true,
       "setable": false,
-      "icon": "assets/icons/globe.svg",
-      "values": [
-        {
-          "id": "online",
-          "title": {
-            "en": "Online"
-          }
-        },
-        {
-          "id": "offline",
-          "title": {
-            "en": "Offline"
-          }
-        }
-      ]
+      "insights": true,
+      "insightsTitleTrue": {
+        "en": "Online"
+      },
+      "insightsTitleFalse": {
+        "en": "Offline"
+      },
+      "icon": "assets/icons/globe.svg"
     }
   }
 }

--- a/drivers/espresense_beacon/device.ts
+++ b/drivers/espresense_beacon/device.ts
@@ -12,8 +12,9 @@ class ESPresenseBeaconDevice extends Homey.Device {
 
   private whenDeviceIsNoLongerDetectedWithinXMinutesCard: FlowCardTriggerDevice|undefined;
   private whenDeviceIsDetectedAfterXMinutesCard: FlowCardTriggerDevice|undefined;
-  
-  private timer?: NodeJS.Timeout;
+  private whenRoomChangesCard: FlowCardTriggerDevice|undefined;
+
+  private timer?: ReturnType<typeof setInterval>;
   private connectionLostIntervalTimeInSeconds = 30;
 
   private boundDeviceMessageHandler? : DeviceMessageFunction;
@@ -41,7 +42,8 @@ class ESPresenseBeaconDevice extends Homey.Device {
     // Flows
     this.whenDeviceIsNoLongerDetectedWithinXMinutesCard = this.homey.flow.getDeviceTriggerCard('beacon-when-device-is-no-longer-detected');
     this.whenDeviceIsDetectedAfterXMinutesCard = this.homey.flow.getDeviceTriggerCard('beacon-when-device-is-detected-after-x-minutes');
-    
+    this.whenRoomChangesCard = this.homey.flow.getDeviceTriggerCard('beacon-when-room-changes');
+
     await this.register();
   }
 
@@ -58,7 +60,7 @@ class ESPresenseBeaconDevice extends Homey.Device {
     if (mapping) {
       deviceName = mapping[this.deviceId];
     }
-    
+
     if (!deviceName) {
       deviceName = name;
     }
@@ -70,7 +72,7 @@ class ESPresenseBeaconDevice extends Homey.Device {
     this.boundDeviceMessageHandler = this.deviceMessageHandler.bind(this);
     this.client?.on('deviceMessage', this.boundDeviceMessageHandler);
     this.boundRoomMessageHandler = this.roomMessageHandler.bind(this);
-    this.client?.on('roomMessage', this.boundRoomMessageHandler); 
+    this.client?.on('roomMessage', this.boundRoomMessageHandler);
   }
 
   async unRegister() {
@@ -85,11 +87,53 @@ class ESPresenseBeaconDevice extends Homey.Device {
   }
 
   async roomMessageHandler(roomId: string, roomProperty?: string, roomPayload? : string) {
-    return; 
+    const currentRoomId = await this.getCapabilityValue('espresense_beacon_room');
+    const currentRoomName = await this.getCapabilityValue('espresense_beacon_roomname');
+    const roomName = this.client?.rooms[roomId]?.name;
+
+    if (currentRoomId === roomId && roomName && currentRoomName !== roomName) {
+      await this.setCapabilityValue('espresense_beacon_roomname', roomName);
+    }
+  }
+
+  private hasValidDistance(distance?: number): distance is number {
+    return typeof distance === 'number' && Number.isFinite(distance);
+  }
+
+  private getRoomName(roomId?: string | null): string {
+    if (!roomId) {
+      return '';
+    }
+
+    return this.client?.rooms[roomId]?.name || roomId;
+  }
+
+  private async setBeaconRoom(deviceRoomId: string, distance: number): Promise<void> {
+    const currentRoomId = await this.getCapabilityValue('espresense_beacon_room');
+    const newRoomName = this.getRoomName(deviceRoomId);
+
+    await this.setCapabilityValue('espresense_beacon_room', deviceRoomId);
+    await this.setCapabilityValue('espresense_beacon_roomname', newRoomName);
+    await this.setCapabilityValue('espresense_distance_capability', distance);
+
+    if (currentRoomId && currentRoomId !== deviceRoomId) {
+      await this.whenRoomChangesCard?.trigger(this, {
+        'room-id': deviceRoomId,
+        'room-name': newRoomName,
+        'previous-room-id': currentRoomId,
+        'previous-room-name': this.getRoomName(currentRoomId),
+        'distance': distance,
+      }, {
+        deviceId: this.deviceId,
+        roomId: deviceRoomId,
+        previousRoomId: currentRoomId,
+        distance,
+      });
+    }
   }
 
   async deviceMessageHandler(deviceId: string, deviceRoomId?: string, device?: ESPresenseDevice) {
-    if (this.deviceId != deviceId) {
+    if (this.deviceId !== deviceId) {
       return;
     }
 
@@ -101,27 +145,21 @@ class ESPresenseBeaconDevice extends Homey.Device {
 
       // We have data, set status online
       await this.setCapabilityValue('espresense_status_capability', ESPresenseStatus.Online);
-      
+
       const currentRoomId = await this.getCapabilityValue('espresense_beacon_room');
       const currentDistance = await this.getCapabilityValue('espresense_distance_capability');
+      const deviceDistance = device.distance;
 
-      if (currentRoomId == deviceRoomId) {
-        // Same room, update distance
-        await this.setCapabilityValue('espresense_distance_capability', device.distance);
-        //this.log("Beacon, update distance:", deviceId, deviceRoomId, "distance:", device.distance);
-      } else if (device.distance && (!currentDistance || (device.distance < currentDistance))) {
-        // Nearest Room
-        if (deviceRoomId) {
-          // Get Room 
-          const room = this.client?.rooms[deviceRoomId];
-          if (room) {
-            await this.setCapabilityValue('espresense_beacon_room', room.id);  
-            await this.setCapabilityValue('espresense_beacon_roomname', room.name);
-          }
+      if (this.hasValidDistance(deviceDistance)) {
+        if (currentRoomId === deviceRoomId) {
+          // Same room, update distance
+          await this.setCapabilityValue('espresense_distance_capability', deviceDistance);
+          //this.log("Beacon, update distance:", deviceId, deviceRoomId, "distance:", deviceDistance);
+        } else if (deviceRoomId && (!this.hasValidDistance(currentDistance) || (deviceDistance < currentDistance))) {
+          // Nearest Room
+          await this.setBeaconRoom(deviceRoomId, deviceDistance);
+          //this.log("Beacon, update room:", deviceId, deviceRoomId, "distance:", deviceDistance);
         }
-
-        await this.setCapabilityValue('espresense_distance_capability', device.distance);
-        //this.log("Beacon, update room:", deviceId, deviceRoomId, "distance:", device.distance);
       }
 
       // Reactivated device
@@ -135,13 +173,13 @@ class ESPresenseBeaconDevice extends Homey.Device {
           flowDuration = flowArguments[0].duration;
         }
 
-        if (flowDuration >= 1 && deltaLastseenTimestamp > flowDuration*60*1000) { 
-           // Run device active again card
-           await this.whenDeviceIsDetectedAfterXMinutesCard?.trigger(this, undefined, {
-             deviceId: device.id,
-             lastseenTimestamp: this.lastseenTimestamp,
-             duration: deltaLastseenTimestamp
-           });
+        if (flowDuration >= 1 && deltaLastseenTimestamp > flowDuration*60*1000) {
+          // Run device active again card
+          await this.whenDeviceIsDetectedAfterXMinutesCard?.trigger(this, undefined, {
+            deviceId: device.id,
+            lastseenTimestamp: this.lastseenTimestamp,
+            duration: deltaLastseenTimestamp
+          });
         }
       }
       this.lastseenTimestamp = currentTimestamp
@@ -158,7 +196,7 @@ class ESPresenseBeaconDevice extends Homey.Device {
           const deltaLastseenTimestamp = currentTimestamp - this.lastseenTimestamp;
 
           // If the device is more than 30 seconds away, set to offline
-          if (deltaLastseenTimestamp > this.connectionLostIntervalTimeInSeconds*1000) { 
+          if (deltaLastseenTimestamp > this.connectionLostIntervalTimeInSeconds*1000) {
             await this.setCapabilityValue('espresense_status_capability', ESPresenseStatus.Offline);
           }
 
@@ -169,16 +207,16 @@ class ESPresenseBeaconDevice extends Homey.Device {
           }
 
           // Run device not responding card if the duration has passed
-          if (flowDuration >= 1 && deltaLastseenTimestamp > flowDuration*60*1000) { 
+          if (flowDuration >= 1 && deltaLastseenTimestamp > flowDuration*60*1000) {
             // Kill timer
             clearInterval(this.timer);
             this.timer = undefined;
 
             // Call trigger
             await this.whenDeviceIsNoLongerDetectedWithinXMinutesCard?.trigger(this, undefined, {
-               deviceId: device.id,
-               lastseenTimestamp: this.lastseenTimestamp,
-               duration: deltaLastseenTimestamp
+              deviceId: device.id,
+              lastseenTimestamp: this.lastseenTimestamp,
+              duration: deltaLastseenTimestamp
             })
           }
         }

--- a/drivers/espresense_beacon/driver.flow.compose.json
+++ b/drivers/espresense_beacon/driver.flow.compose.json
@@ -47,6 +47,97 @@
           "step": 1
         }
       ]
+    },
+    {
+      "id": "beacon-when-room-changes",
+      "title": {
+        "en": "When beacon changes room",
+        "nl": "Als beacon van ruimte wisselt"
+      },
+      "titleFormatted": {
+        "en": "When beacon changes room",
+        "nl": "Als beacon van ruimte wisselt"
+      },
+      "tokens": [
+        {
+          "type": "string",
+          "name": "room-name",
+          "title": {
+            "en": "New room",
+            "nl": "Nieuwe ruimte"
+          },
+          "example": {
+            "en": "Bedroom front"
+          }
+        },
+        {
+          "type": "string",
+          "name": "room-id",
+          "title": {
+            "en": "New room ID",
+            "nl": "Nieuwe ruimte ID"
+          },
+          "example": {
+            "en": "bedroom-front"
+          }
+        },
+        {
+          "type": "string",
+          "name": "previous-room-name",
+          "title": {
+            "en": "Previous room",
+            "nl": "Vorige ruimte"
+          },
+          "example": {
+            "en": "Storage 1"
+          }
+        },
+        {
+          "type": "string",
+          "name": "previous-room-id",
+          "title": {
+            "en": "Previous room ID",
+            "nl": "Vorige ruimte ID"
+          },
+          "example": {
+            "en": "storage-1"
+          }
+        },
+        {
+          "type": "number",
+          "name": "distance",
+          "title": {
+            "en": "Distance",
+            "nl": "Afstand"
+          },
+          "example": {
+            "en": "1.2"
+          }
+        }
+      ]
+    }
+  ],
+  "conditions": [
+    {
+      "id": "beacon-is-in-room",
+      "title": {
+        "en": "Closest node is room",
+        "nl": "Dichtstbijzijnde node is ruimte"
+      },
+      "titleFormatted": {
+        "en": "Closest node is [[roomId]]",
+        "nl": "Dichtstbijzijnde node is [[roomId]]"
+      },
+      "args": [
+        {
+          "type": "autocomplete",
+          "name": "roomId",
+          "placeholder": {
+            "en": "Room",
+            "nl": "Ruimte"
+          }
+        }
+      ]
     }
   ]
 }

--- a/drivers/espresense_beacon/driver.ts
+++ b/drivers/espresense_beacon/driver.ts
@@ -8,6 +8,65 @@ class ESPresenseBeaconDriver extends Homey.Driver {
 
   private whenDeviceIsNoLongerDetectedWithinXMinutesCard: FlowCardTriggerDevice|undefined;
   private whenDeviceIsDetectedAfterXMinutesCard: FlowCardTriggerDevice|undefined;
+  private whenRoomChangesCard: FlowCardTriggerDevice|undefined;
+  private beaconIsInRoomCard: FlowCard|undefined;
+
+  private getRoomIdFromArgument(roomArgument: any): string|undefined {
+    if (!roomArgument) {
+      return undefined;
+    }
+
+    if (typeof roomArgument === 'string') {
+      return roomArgument;
+    }
+
+    return roomArgument.id;
+  }
+
+  private getRoomSuggestions(): FlowCard.ArgumentAutocompleteResults {
+    const suggestionsById: { [key: string]: { id: string; name: string; description?: string } } = {};
+
+    try {
+      const nodeDriver = this.homey.drivers.getDriver('espresense');
+      nodeDriver.getDevices().forEach((device: Homey.Device) => {
+        const roomId = device.getData().id;
+        if (roomId) {
+          suggestionsById[roomId] = {
+            id: roomId,
+            name: device.getName(),
+            description: roomId,
+          };
+        }
+      });
+    } catch (error) {
+      this.log('Could not read paired ESPresense nodes for room autocomplete', error);
+    }
+
+    if (this.client) {
+      Object.values(this.client.rooms).forEach((room) => {
+        if (room.id && !suggestionsById[room.id]) {
+          suggestionsById[room.id] = {
+            id: room.id,
+            name: room.name || room.id,
+            description: room.id,
+          };
+        }
+      });
+    }
+
+    return Object.values(suggestionsById).sort((first, second) => first.name.localeCompare(second.name));
+  }
+
+  async roomAutocompleteListener(query: string, args: any): Promise<FlowCard.ArgumentAutocompleteResults> {
+    const normalizedQuery = (query || '').toLowerCase();
+    const suggestions = this.getRoomSuggestions();
+
+    if (!normalizedQuery) {
+      return suggestions;
+    }
+
+    return suggestions.filter((item) => item.name.toLowerCase().includes(normalizedQuery) || item.id.toLowerCase().includes(normalizedQuery));
+  }
   
   async onInit() {
     this.log('ESPresenseBeaconDriver has been initialized');
@@ -20,6 +79,24 @@ class ESPresenseBeaconDriver extends Homey.Driver {
     this.whenDeviceIsDetectedAfterXMinutesCard = this.homey.flow.getDeviceTriggerCard('beacon-when-device-is-detected-after-x-minutes');
     this.whenDeviceIsDetectedAfterXMinutesCard.registerRunListener(async (args: any, state: any) => {
       return true;
+    });
+
+    this.whenRoomChangesCard = this.homey.flow.getDeviceTriggerCard('beacon-when-room-changes');
+    this.whenRoomChangesCard.registerRunListener(async (args: any, state: any) => {
+      return true;
+    });
+
+    this.beaconIsInRoomCard = this.homey.flow.getConditionCard('beacon-is-in-room');
+    this.beaconIsInRoomCard.registerArgumentAutocompleteListener('roomId', this.roomAutocompleteListener.bind(this));
+    this.beaconIsInRoomCard.registerRunListener(async (args: any, state: any) => {
+      const roomId = this.getRoomIdFromArgument(args.roomId);
+      const beaconDevice = args.device as Homey.Device|undefined;
+
+      if (!roomId || !beaconDevice) {
+        return false;
+      }
+
+      return await beaconDevice.getCapabilityValue('espresense_beacon_room') === roomId;
     });
   }
   


### PR DESCRIPTION
This PR adds two new Flow cards for ESPresense beacon devices:

- A device trigger card for when a beacon changes room
- A condition card to check whether the beacon's closest node/room matches a selected node

The room-change trigger exposes Flow tokens for:
- New room name
- New room ID
- Previous room name
- Previous room ID
- Distance

The condition card uses autocomplete suggestions based on paired ESPresense nodes and known ESPresense rooms.

Tested locally on Homey Pro 2023 with:
- Existing ESPresense nodes
- Existing beacons
- MQTT connection
- Room changes between nodes
- New room-change trigger
- New closest-node condition
- Existing beacon status/room/distance functionality

Validation:
- npm run build
- homey app validate
- homey app run
- homey app install